### PR TITLE
File submission 401

### DIFF
--- a/classes/file_storage.php
+++ b/classes/file_storage.php
@@ -17,7 +17,7 @@
 namespace mod_questionnaire;
 
 /**
- * Defines the file stoeage class for questionnaire.
+ * Defines the file storage class for questionnaire.
  * @package mod_questionnaire
  * @copyright  2020 onwards Mike Churchward (mike.churchward@poetopensource.org)
  * @author Mike Churchward

--- a/classes/question/file.php
+++ b/classes/question/file.php
@@ -81,7 +81,7 @@ class file extends question {
         $elname = 'q' . $this->id;
         $draftitemid = file_get_submitted_draft_itemid($elname);
         $component = 'mod_questionnaire';
-        $options = $this->get_file_manager_option();
+        $options = self::get_file_manager_option();
         if ($draftitemid > 0) {
             file_prepare_draft_area($draftitemid, $this->context->id, $component, 'file', $this->id, $options);
         } else {
@@ -114,7 +114,7 @@ class file extends question {
      *
      * @return array
      */
-    private function get_file_manager_option() {
+    public static function get_file_manager_option() {
         return [
             'mainfile' => '',
             'subdirs' => false,

--- a/classes/question/file.php
+++ b/classes/question/file.php
@@ -82,7 +82,11 @@ class file extends question {
         $draftitemid = file_get_submitted_draft_itemid($elname);
         $component = 'mod_questionnaire';
         $options = $this->get_file_manager_option();
-        file_prepare_draft_area($draftitemid, $this->context->id, $component, 'file', $this->id, $options);
+        if ($draftitemid > 0) {
+            file_prepare_draft_area($draftitemid, $this->context->id, $component, 'file', $this->id, $options);
+        } else {
+            $draftitemid = file_get_unused_draft_itemid();
+        }
         // Filemanager form element implementation is far from optimal, we need to rework this if we ever fix it...
         require_once("$CFG->dirroot/lib/form/filemanager.php");
 

--- a/classes/question/file.php
+++ b/classes/question/file.php
@@ -70,12 +70,12 @@ class file extends question {
     /**
      * Survey display output.
      *
-     * @param response $response
+     * @param \stdClass $formdata
      * @param object $descendantsdata
      * @param bool $blankquestionnaire
-     * @return object|string
+     * @return string
      */
-    protected function question_survey_display($response, $descendantsdata, $blankquestionnaire = false) {
+    protected function question_survey_display($formdata, $descendantsdata, $blankquestionnaire = false) {
         global $CFG, $PAGE;
         require_once($CFG->libdir . '/filelib.php');
         $elname = 'q' . $this->id;
@@ -114,27 +114,29 @@ class file extends question {
         return [
             'mainfile' => '',
             'subdirs' => false,
-            'accepted_types' => array('image', '.pdf')
+            'accepted_types' => array('image', '.pdf'),
+            'maxfiles' => 1,
         ];
     }
 
     /**
      * Response display output.
      *
-     * @param response $response
-     * @return object|string
+     * @param \stdClass $data
+     * @return string
      */
-    protected function response_survey_display($response) {
+    protected function response_survey_display($data) {
         global $PAGE, $CFG;
         require_once($CFG->libdir . '/filelib.php');
         require_once($CFG->libdir . '/resourcelib.php');
-        if (isset($response->answers[$this->id])) {
-            $answer = reset($response->answers[$this->id]);
+        if (isset($data->answers[$this->id])) {
+            $answer = reset($data->answers[$this->id]);
         } else {
             return '';
         }
         $fs = get_file_storage();
         $file = $fs->get_file_by_id($answer->value);
+        $code = '';
 
         if ($file) {
             // There is a file.
@@ -149,8 +151,6 @@ class file extends question {
 
             $mimetype = $file->get_mimetype();
             $title = '';
-
-            $extension = resourcelib_get_extension($file->get_filename());
 
             $mediamanager = core_media_manager::instance($PAGE);
             $embedoptions = array(
@@ -177,11 +177,7 @@ class file extends question {
                 $code = resourcelib_embed_general($moodleurl, $title, get_string('view'), $mimetype);
             }
         }
-        $output = '';
-        $output .= '<div class="response text">';
-        $output .= $code;
-        $output .= '</div>';
-        return $output;
+        return '<div class="response text">' . $code . '</div>';
     }
 
     /**

--- a/classes/responsetype/file.php
+++ b/classes/responsetype/file.php
@@ -135,7 +135,7 @@ class file extends responsetype {
             $record->question_id = $this->question->id;
             $record->fileid = intval(clean_text($response->answers[$this->question->id][0]->value));
 
-            // When saving the draft file, the itemid was the same as the draftfileid. This must now be
+            // When saving the draft file, the itemid was the same as the draftitemid. This must now be
             // corrected to the primary key that is questionaire_response_file.id to have a correct reference.
             $recordid = $DB->insert_record(static::response_table(), $record);
             if ($recordid) {
@@ -146,7 +146,7 @@ class file extends responsetype {
                 $siblings = $DB->get_records('files',
                     ['component' => 'mod_questionnaire', 'itemid' => $olditem->itemid]);
                 foreach ($siblings as $sibling) {
-                    if (!$this->fix_file_itemid($recordid, $sibling)) {
+                    if (!self::fix_file_itemid($recordid, $sibling)) {
                         return false;
                     }
                 }
@@ -164,8 +164,11 @@ class file extends responsetype {
      * @return bool
      * @throws \dml_exception
      */
-    protected function fix_file_itemid(int $recordid, \stdClass $filerecord): bool {
+    public static function fix_file_itemid(int $recordid, \stdClass $filerecord): bool {
         global $DB;
+        if ((int)$filerecord->itemid === $recordid) {
+            return true; // Reference is already good, nothing to do.
+        }
         $fs = get_file_storage();
         $file = $fs->get_file_instance($filerecord);
         $newhash = $fs->get_pathname_hash($filerecord->contextid, $filerecord->component,

--- a/classes/responsetype/file.php
+++ b/classes/responsetype/file.php
@@ -43,9 +43,9 @@ class file extends responsetype {
             $record->responseid = $responsedata->rid;
             $record->questionid = $question->id;
 
-            file_save_draft_area_files($val, $question->context->id, 'mod_questionnaire', 'file', $responsedata->rid);
+            file_save_draft_area_files($val, $question->context->id, 'mod_questionnaire', 'file', $question->id);
             $fs = get_file_storage();
-            $files = $fs->get_area_files($question->context->id, 'mod_questionnaire', 'file', $responsedata->rid,
+            $files = $fs->get_area_files($question->context->id, 'mod_questionnaire', 'file', $question->id,
                 "itemid, filepath, filename",
                 false);
             $file = reset($files);

--- a/classes/responsetype/file.php
+++ b/classes/responsetype/file.php
@@ -48,9 +48,11 @@ class file extends responsetype {
             $files = $fs->get_area_files($question->context->id, 'mod_questionnaire', 'file', $question->id,
                 "itemid, filepath, filename",
                 false);
-            $file = reset($files);
-            $record->value = $file->get_id();
-            $answers[] = answer\answer::create_from_data($record);
+            if (!empty($files)) {
+                $file = reset($files);
+                $record->value = $file->get_id();
+                $answers[] = answer\answer::create_from_data($record);
+            }
         }
         return $answers;
     }

--- a/classes/responsetype/response/response.php
+++ b/classes/responsetype/response/response.php
@@ -99,9 +99,9 @@ class response {
     /**
      * Provide a response object from web form data to the question.
      *
-     * @param \stdClass $responsedata All of the responsedata as an object.
+     * @param \stdClass $responsedata All the responsedata as an object.
      * @param array $questions
-     * @return bool|response A response object.
+     * @return response A response object.
      */
     public static function response_from_webform($responsedata, $questions) {
         global $USER;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1030,6 +1030,19 @@ function xmldb_questionnaire_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2023101500, 'questionnaire');
     }
 
+    if ($oldversion < 2023101501) {
+        // Upgrade files.itemid with questionnaire_response_file.id
+        $filesresponses = $DB->get_records('questionnaire_response_file', [], '', 'id,fileid');
+        $idmap = [];
+        foreach ($filesresponses as $fileresponse) {
+            $idmap[(int)$fileresponse->fileid] = (int)$fileresponse->id;
+        }
+        $filerecords = $DB->get_records_list('files', 'id', array_keys($idmap), 'id desc');
+        foreach ($filerecords as $filerecord) {
+            \mod_questionnaire\responsetype\file::fix_file_itemid($idmap[(int)$filerecord->id], $filerecord);
+        }
+    }
+
     return $result;
 }
 

--- a/lib.php
+++ b/lib.php
@@ -548,7 +548,7 @@ function questionnaire_pluginfile($course, $cm, $context, $filearea, $args, $for
             return false;
         }
     } else if ($filearea == 'file') {
-        if (!$DB->record_exists('questionnaire_response_file', ['response_id' => $componentid])) {
+        if (!$DB->record_exists('questionnaire_response_file', ['id' => $componentid])) {
             return false;
         }
     } else {

--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -122,12 +122,12 @@ class questionnaire {
 
     /**
      * Adding questions to the object.
-     * @param bool $sid
+     * @param int $sid
      */
-    public function add_questions($sid = false) {
+    public function add_questions($sid = 0) {
         global $DB;
 
-        if ($sid === false) {
+        if ($sid === 0) {
             $sid = $this->sid;
         }
 

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2023101500;  // The current module version (Date: YYYYMMDDXX).
+$plugin->version = 2023101501;  // The current module version (Date: YYYYMMDDXX).
 $plugin->requires = 2022112800.00; // Moodle version (4.1.0).
 
 $plugin->component = 'mod_questionnaire';
 
-$plugin->release = '4.1.1 (Build - 2023101500)';
+$plugin->release = '4.1.1 (Build - 2023101501)';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Fix handling of file uploads
- Handle several question type files.
- Allow upload of one file only per question type file.
- New submit does not load previously existing files.
- Adjust siganture of methods to their parent
- Use questionaire id for file draft area instead of question id in the questionaire.
- Do not prefill file uploads with previous files

What is missing/problematic
- Files are not assigned correctly to the corresponding answer, when the form contains errors
- Files are lost when another answer is added.
